### PR TITLE
Fixed readme link

### DIFF
--- a/FlashPro_Express_Projects/README.md
+++ b/FlashPro_Express_Projects/README.md
@@ -49,7 +49,7 @@ The programming files contained under this folder were exported from the designs
 ## Design Features
 
 > MI-V Extended Subsystem Design Guide Configurations:
-> * For **DGC2: I2C Write & Boot** design features, refer to [DGC2 README](../Libero_Projects/import/components/IMC_DGC2/README.md)
+> * For **DGC2: I2C Write & Boot** design features, refer to [DGC2 README](../docs/design_dgc2/README.md)
 
 The following applies only to non MIV_ESS Design Guide: Design Guide Configurations (DGC2)
 


### PR DESCRIPTION
Fixed the broken link for DGC2 README in ./FlashPro_Express_Projects/README.md

<Signed-off: sebastian.slowikowski@microchip.com>